### PR TITLE
README code now executes without error

### DIFF
--- a/pry/pry.go
+++ b/pry/pry.go
@@ -47,7 +47,7 @@ func Apply(v Scope) {
 		end = len(lines)
 	}
 	maxLength := len(fmt.Sprint(end))
-	for i := start; i <= end; i++ {
+	for i := start; i < end; i++ {
 		caret := "  "
 		if i == lineNum {
 			caret = "=>"


### PR DESCRIPTION
 Fixes #1 

Not sure if this is the *right* fix, but I noticed that the for loop termination condition seemed to be the source of the out-of-range error. After making this change, the README sample code worked for me.