### PR TITLE
Adding instructions for installing `gocode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Example
 
 
 ## Usage
+
 Install go-pry
 ```bash
 go get github.com/d4l3k/go-pry
@@ -39,6 +40,14 @@ Run the code as you would normally with the `go` command. go-pry is just a wrapp
 # Run
 go-pry run readme.go
 ```
+
+If you want completions to work properly, also install `gocode` if it
+is not installed in your system
+
+```bash
+go get -u github.com/nsf/gocode
+```
+
 
 ## How does it work?
 go-pry is built using a combination of meta programming as well as a massive amount of reflection. When you invoke the go-pry command it looks at the Go files in the mentioned directories (or the current in cases such as `go-pry build`) and processes them. Since Go is a compiled language there's no way to dynamically get in scope variables, and even if there was, unused imports would be automatically removed for optimization purposes. Thus, go-pry has to find every instance of `pry.Pry()` and inject a large blob of code that contains references to all in scope variables and functions as well as those of the imported packages. When doing this it makes a copy of your file to `.<filename>.gopry` and modifies the `<filename>.go` then passes the command arguments to the standard `go` command. Once the command exits, it restores the files.


### PR DESCRIPTION
When accepted, closes #11. 
Just a little dox fixup.