### PR TITLE
Add -i flag to go install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Example
 Install go-pry
 ```bash
 go get github.com/d4l3k/go-pry
-go install github.com/d4l3k/go-pry
+go install -i github.com/d4l3k/go-pry
 
 ```
 


### PR DESCRIPTION
Running go install without the -i flag on macOS will sometimes lead to a "panic: failed to TypeCheck" when running `go-pry`. See issue https://github.com/d4l3k/go-pry/issues/49 for more information.