### PR TITLE
dropped support for pre 1.7 go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: go
 
 go:
-  - 1.5
-  - 1.6
   - 1.7.x
   - 1.8.x
+  - 1.9.x
+  - 1.10.x
   - tip
 
 install:


### PR DESCRIPTION
The exponential backoff package we use in tests dropped support for go1.6.

https://github.com/cenkalti/backoff/pull/59